### PR TITLE
Fix KotlinTypesafeChangeLogSerializer.sourceRootPath

### DIFF
--- a/integration-test/src/test/kotlin/momosetkn/KotlinTypesafeMigrateAndSerializeSpec.kt
+++ b/integration-test/src/test/kotlin/momosetkn/KotlinTypesafeMigrateAndSerializeSpec.kt
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 class KotlinTypesafeMigrateAndSerializeSpec : FunSpec({
     beforeSpec {
         Database.start()
-        KotlinTypesafeChangeLogSerializer.sourceRootDirectory = Paths.get(RESOURCE_DIR)
+        KotlinTypesafeChangeLogSerializer.sourceRootPath = Paths.get(RESOURCE_DIR)
     }
     afterSpec {
         Database.stop()

--- a/typesafe-serializer/src/main/kotlin/KotlinTypesafeChangeLogSerializer.kt
+++ b/typesafe-serializer/src/main/kotlin/KotlinTypesafeChangeLogSerializer.kt
@@ -49,7 +49,7 @@ class KotlinTypesafeChangeLogSerializer : ChangeLogSerializer {
         val filePath = (changeSets[0] as? ChangeSet)?.filePath
             ?: return ""
         return filePath
-            .removePrefix(sourceRootDirectory.toString())
+            .removePrefix(sourceRootPath.toString())
             .removePrefix("/")
             .substringBeforeLast("/")
             .replace("/", ".")
@@ -72,6 +72,6 @@ class KotlinTypesafeChangeLogSerializer : ChangeLogSerializer {
         )
 
     companion object {
-        var sourceRootDirectory = java.nio.file.Path.of("src.main.kotlin")
+        var sourceRootPath = java.nio.file.Path.of("src/main/kotlin")
     }
 }


### PR DESCRIPTION
fix bug that can't be removed "src/main/kotlin"