### PR TITLE
Remove clazz, className property

### DIFF
--- a/dsl/src/main/kotlin/momosetkn/liquibase/kotlin/dsl/ChangeSetDsl.kt
+++ b/dsl/src/main/kotlin/momosetkn/liquibase/kotlin/dsl/ChangeSetDsl.kt
@@ -1322,26 +1322,19 @@ class ChangeSetDsl(
 
     /**
      * Applies a custom-change to the change set.
-     * This function requires at least one of the parameters `class`, `clazz`, or `className`.
      * Class is requiring implements the [liquibase.change.custom.CustomChange]
      * [official-document](https://docs.liquibase.com/change-types/custom-change.html)
      *
      * @param `class` specify KClass or Class<*> of CustomChange or className of CustomChange.
-     * @param clazz specify KClass or Class<*> of CustomChange or className of CustomChange. not official param.
-     * @param className className of CustomChange. not official param.
      * @param block Key-value to be given to CustomChange.
      */
     fun customChange(
         @Suppress("FunctionParameterNaming")
-        `class`: Any? = null,
-        clazz: Any? = null,
-        className: String? = null,
+        `class`: Any,
         block: (KeyValueDsl.() -> Unit)? = null,
     ) {
-        val overrideClassName = (`class` ?: clazz ?: className)
-            ?: error("Should specify either 'class' or 'clazz' or 'className' property for 'customChange'")
         val change = changeSetSupport.createChange("customChange") as CustomChangeWrapper
-        change.setClass(overrideClassName.evalClassNameExpressions(changeLog))
+        change.setClass(`class`.evalClassNameExpressions(changeLog))
         block?.let {
             val dsl = KeyValueDsl(changeLog)
             val map = wrapChangeLogParseException { dsl(block) }

--- a/dsl/src/main/kotlin/momosetkn/liquibase/kotlin/dsl/ChangeSetDsl.kt
+++ b/dsl/src/main/kotlin/momosetkn/liquibase/kotlin/dsl/ChangeSetDsl.kt
@@ -1408,6 +1408,16 @@ class ChangeSetDsl(
         changeSetSupport.addChange(change)
     }
 
+    /**
+     * Executes a raw SQL change.
+     * [official-document](https://docs.liquibase.com/change-types/sql.html)
+     *
+     * @param dbms The type of database. [database-type](https://docs.liquibase.com/start/tutorials/home.html)
+     * @param endDelimiter The delimiter for the end of the SQL statement. Default is ";".
+     * @param splitStatements Whether to split the SQL statements. Default is true.
+     * @param stripComments Whether to strip comments from the SQL. Default is true.
+     * @param block The DSL-block that returns SQL strings
+     */
     fun sql(
         dbms: String? = null,
         endDelimiter: String? = null,
@@ -1446,14 +1456,17 @@ class ChangeSetDsl(
         stripComments: Boolean? = null,
         comment: String? = null,
     ) {
-        val change = changeSetSupport.createChange("sql") as RawSQLChange
-        change.dbms = dbms
-        change.endDelimiter = endDelimiter
-        change.isSplitStatements = splitStatements
-        change.isStripComments = stripComments
-        change.sql = sql.evalExpressions(changeLog)
-        change.comment = comment?.evalExpressions(changeLog)
-        changeSetSupport.addChange(change)
+        sql(
+            dbms = dbms,
+            endDelimiter = endDelimiter,
+            splitStatements = splitStatements,
+            stripComments = stripComments,
+        ) {
+            if (comment != null) {
+                comment(comment)
+            }
+            sql
+        }
     }
 
     /**

--- a/dsl/src/main/kotlin/momosetkn/liquibase/kotlin/dsl/PreConditionDsl.kt
+++ b/dsl/src/main/kotlin/momosetkn/liquibase/kotlin/dsl/PreConditionDsl.kt
@@ -240,28 +240,21 @@ class PreConditionDsl<PRECONDITION_LOGIC : PreconditionLogic>(
 
     /**
      * Applies a custom-precondition to the preconditions.
-     * This function requires at least one of the parameters `class`, `clazz`, or `className`.
      * Class is requiring implements the [liquibase.precondition.CustomPrecondition]
      * [official-document](https://docs.liquibase.com/concepts/changelogs/preconditions.html)
      *
      * @param `class` specify KClass or Class<*> of CustomChange or className of CustomChange.
-     * @param clazz specify KClass or Class<*> of CustomChange or className of CustomChange. not official param.
-     * @param className className of CustomChange. not official param.
      * @param block Key-value to be given to CustomChange.
      */
     fun customPrecondition(
         @Suppress("FunctionParameterNaming")
-        `class`: Any? = null,
-        clazz: Any? = null,
-        className: String? = null,
+        `class`: Any,
         block: KeyValueDsl.() -> Unit,
     ) {
         val precondition = CustomPreconditionWrapper()
 
         @Suppress("MaxLineLength")
-        val overrideClassName = (`class` ?: clazz ?: className)
-            ?: error("Should specify either 'class' or 'clazz' or 'className' property for 'customPrecondition' preConditions")
-        precondition.className = overrideClassName.evalClassNameExpressions(changeLog)
+        precondition.className = `class`.evalClassNameExpressions(changeLog)
         val dsl = KeyValueDsl(changeLog)
         val map = dsl(block)
         map.forEach { (key, value) ->


### PR DESCRIPTION
If there are too many options, users will get confused, so we need to unify them.