### PR TITLE
Add test-snapshot-liquibase CI

### DIFF
--- a/.github/workflows/test-snapshot-liquibase.yml
+++ b/.github/workflows/test-snapshot-liquibase.yml
@@ -1,6 +1,7 @@
 name: test snapshot-version Liquibase
 
 on:
+  workflow_dispatch:
   schedule:
     - cron:  '0 0 * * *'
 

--- a/.github/workflows/test-snapshot-liquibase.yml
+++ b/.github/workflows/test-snapshot-liquibase.yml
@@ -1,7 +1,6 @@
 name: test snapshot-version Liquibase
 
 on:
-  push: # FIXME: remove push event
   schedule:
     - cron:  '0 0 * * *'
 

--- a/.github/workflows/test-snapshot-liquibase.yml
+++ b/.github/workflows/test-snapshot-liquibase.yml
@@ -1,0 +1,52 @@
+name: test snapshot-version Liquibase
+
+on:
+  push: # FIXME: remove push event
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Fetch latest SNAPSHOT version from GitHub Packages
+        id: liquibase-core-latest-snapshot-version
+        run: |
+          LATEST_VERSION=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/orgs/liquibase/packages/maven/org.liquibase.liquibase-core/versions | \
+          jq -r '.[0].name')
+          echo "Latest version is $LATEST_VERSION"
+          echo "version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Configure Gradle for GitHub Packages
+        run: |
+          echo "gpr.user=${{ github.actor }}" >> ~/.gradle/gradle.properties
+          echo "gpr.token=${{ secrets.GITHUB_TOKEN }}" >> ~/.gradle/gradle.properties
+
+      - name: Test using latest liquibase SNAPSHOT version
+        run: |
+          ./gradlew test -PliquibaseVersion=${{ steps.liquibase-core-latest-snapshot-version.outputs.version }}
+
+      - name: Upload reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'reports-${{ matrix.os }}'
+          path: ./**/build/reports

--- a/.github/workflows/test-snapshot-liquibase.yml
+++ b/.github/workflows/test-snapshot-liquibase.yml
@@ -39,7 +39,7 @@ jobs:
           echo "gpr.user=${{ github.actor }}" >> ~/.gradle/gradle.properties
           echo "gpr.token=${{ secrets.GITHUB_TOKEN }}" >> ~/.gradle/gradle.properties
 
-      - name: Test using latest liquibase SNAPSHOT version
+      - name: Test with latest liquibase SNAPSHOT version
         run: |
           ./gradlew test -PliquibaseVersion=${{ steps.liquibase-core-latest-snapshot-version.outputs.version }}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,13 @@ allprojects {
 
     repositories {
         mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/liquibase/liquibase")
+            credentials {
+                username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.token") as String? ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,5 +1,4 @@
 import java.util.Properties
-import kotlin.io.path.Path
 
 val kotestVersion = rootProject.properties["kotestVersion"] as String
 val slf4jVersion = rootProject.properties["slf4jVersion"] as String
@@ -9,7 +8,7 @@ val liquibaseVersion = getSnapshotOrDefaultVersion("liquibaseVersion")
 
 fun loadDefaultProperty(propertyName: String): String {
     val gradleProps = Properties()
-    val gradlePropertiesFile = Path(rootProject.path).resolveSibling("gradle.properties").toFile()
+    val gradlePropertiesFile = rootProject.projectDir.resolve("gradle.properties")
     gradlePropertiesFile.inputStream().use { gradleProps.load(it) }
     return gradleProps.getProperty(propertyName)
 }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,12 +1,32 @@
-// liquibase-kotlin-client is tested only this version
-val latestLiquibaseVersion = "4.29.2"
+import java.util.Properties
+
 val kotestVersion = rootProject.properties["kotestVersion"] as String
 val slf4jVersion = rootProject.properties["slf4jVersion"] as String
 val kotlinVersion = rootProject.properties["kotlinVersion"] as String
+// liquibase-kotlin-client is tested snapshot or latest-stable version
+val liquibaseVersion = getSnapshotOrDefaultVersion("liquibaseVersion")
+
+fun loadDefaultProperty(propertyName: String): String {
+    val gradleProps = Properties()
+    val gradlePropertiesFile = file(rootProject.path).toPath().resolveSibling("gradle.properties").toFile()
+    gradlePropertiesFile.inputStream().use { gradleProps.load(it) }
+    return gradleProps.getProperty(propertyName)
+}
+
+fun getSnapshotOrDefaultVersion(propertyName: String): String {
+    val version = rootProject.properties[propertyName] as String
+    return if (version.any { it.isLetter() }) {
+        // snapshot
+        version
+    } else {
+        // latest-stable
+        loadDefaultProperty(propertyName)
+    }
+}
 
 dependencies {
     // liquibase
-    implementation("org.liquibase:liquibase-core:$latestLiquibaseVersion")
+    implementation("org.liquibase:liquibase-core:$liquibaseVersion")
     // log
     api("org.slf4j:slf4j-api:$slf4jVersion")
 

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.util.Properties
+import kotlin.io.path.Path
 
 val kotestVersion = rootProject.properties["kotestVersion"] as String
 val slf4jVersion = rootProject.properties["slf4jVersion"] as String
@@ -8,7 +9,7 @@ val liquibaseVersion = getSnapshotOrDefaultVersion("liquibaseVersion")
 
 fun loadDefaultProperty(propertyName: String): String {
     val gradleProps = Properties()
-    val gradlePropertiesFile = file(rootProject.path).toPath().resolveSibling("gradle.properties").toFile()
+    val gradlePropertiesFile = Path(rootProject.path).resolveSibling("gradle.properties").toFile()
     gradlePropertiesFile.inputStream().use { gradleProps.load(it) }
     return gradleProps.getProperty(propertyName)
 }


### PR DESCRIPTION
In order to quickly catch up with the release of the new version of Liquibase, we will also regularly run tests with the latest SNAPSHOT version.
There have been issues with the previous Liquibase DSL not being compatible with the new version, so this is important.