### PR TITLE
Omit `verbose = true`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,8 +138,6 @@ configure(libraryProjects) {
         val autherName: String by project
         val autherEmail: String by project
 
-        verbose = true
-
         projectInfo {
             name = rootProject.name
             description = rootProject.description


### PR DESCRIPTION
because redundant log was outputed.