### PR TITLE
Support concurrent liquibase

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,7 +111,9 @@ val libraryProjects =
             "custom-ktorm-change",
             // starter
             "starter-compiled",
-            "starter-script"
+            "starter-script",
+            // internal
+            "liquibase-internal",
         )
     }
 configure(libraryProjects) {

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -6,6 +6,7 @@ val liquibaseVersion = rootProject.properties["liquibaseVersion"] as String
 dependencies {
     // liquibase
     implementation("org.liquibase:liquibase-core:$liquibaseVersion")
+    api(project(":liquibase-internal"))
     // log
     api("org.slf4j:slf4j-api:$slf4jVersion")
 

--- a/client/detekt-baseline.xml
+++ b/client/detekt-baseline.xml
@@ -2,6 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ForbiddenComment:ChangeLogSpec.kt$ChangeLogSpec$// FIXME: failed. liquibase bug?</ID>
+    <ID>ForbiddenComment:LiquibaseClient.kt$LiquibaseClient.Companion$// TODO: mopve ConfigureLiquibase</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/client/src/main/kotlin/momosetkn/liquibase/client/ExtendedLiquibase.kt
+++ b/client/src/main/kotlin/momosetkn/liquibase/client/ExtendedLiquibase.kt
@@ -4,15 +4,23 @@ import liquibase.Contexts
 import liquibase.LabelExpression
 import liquibase.Liquibase
 import liquibase.Scope
+import liquibase.command.CommandScope
+import liquibase.command.core.GenerateChangelogCommandStep
+import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep
+import liquibase.command.core.helpers.PreCompareCommandStep
+import liquibase.command.core.helpers.ReferenceDbUrlConnectionCommandStep
 import liquibase.database.Database
 import liquibase.exception.LiquibaseException
 import liquibase.resource.ResourceAccessor
+import liquibase.structure.DatabaseObject
+import java.io.PrintStream
 import java.io.Writer
 
 class ExtendedLiquibase(
     changeLogFile: String,
     database: Database,
     resourceAccessor: ResourceAccessor = Scope.getCurrentScope().resourceAccessor,
+    private val createPrintStream: () -> PrintStream,
 ) : Liquibase(changeLogFile, resourceAccessor, database,) {
     // to public futureRollbackSQL method, because the original futureRollbackSQL method is protected.
     @Throws(LiquibaseException::class)
@@ -25,5 +33,20 @@ class ExtendedLiquibase(
         checkLiquibaseTables: Boolean
     ) {
         return futureRollbackSQL(count, tag, contexts, labelExpression, output, checkLiquibaseTables)
+    }
+
+    fun diffChangelog(
+        referenceDatabase: Database,
+        outputStream: PrintStream = createPrintStream(),
+        vararg snapshotTypes: Class<out DatabaseObject?>?
+    ) {
+        // Reference liquibase.command.core.DiffToChangeLogCommand.run
+        CommandScope("diffChangelog")
+            .addArgumentValue(GenerateChangelogCommandStep.CHANGELOG_FILE_ARG, changeLogFile)
+            .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, database)
+            .addArgumentValue(ReferenceDbUrlConnectionCommandStep.REFERENCE_DATABASE_ARG, referenceDatabase)
+            .addArgumentValue(PreCompareCommandStep.SNAPSHOT_TYPES_ARG, snapshotTypes)
+            .setOutput(outputStream)
+            .execute()
     }
 }

--- a/command-client/detekt-baseline.xml
+++ b/command-client/detekt-baseline.xml
@@ -2,6 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ForbiddenComment:ChangeLogSpec.kt$ChangeLogSpec$// FIXME: failed. liquibase bug?</ID>
+    <ID>ForbiddenComment:LiquibaseCommandExecutor.kt$LiquibaseCommandExecutor$// TODO: mopve ConfigureLiquibase</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/command-client/detekt-baseline.xml
+++ b/command-client/detekt-baseline.xml
@@ -2,6 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ForbiddenComment:LiquibaseCommandExecutor.kt$LiquibaseCommandExecutor$// TODO: mopve ConfigureLiquibase</ID>
+    <ID>ForbiddenComment:LiquibaseCommandClient.kt$LiquibaseCommandClient.Companion$// TODO: mopve ConfigureLiquibase</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/command-client/src/main/kotlin/momosetkn/liquibase/command/client/LiquibaseCommandClient.kt
+++ b/command-client/src/main/kotlin/momosetkn/liquibase/command/client/LiquibaseCommandClient.kt
@@ -2926,4 +2926,9 @@ class LiquibaseCommandClient(
     private fun listOfNotNullStringToString(vararg keyValue: Pair<String, Any>?): List<Pair<String, String>> {
         return keyValue.filterNotNull().map { (k, v) -> k to v.toString() }
     }
+
+    companion object {
+        // TODO: mopve ConfigureLiquibase
+        var everyUseNewClassloader = false
+    }
 }

--- a/command-client/src/main/kotlin/momosetkn/liquibase/command/client/LiquibaseCommandExecutor.kt
+++ b/command-client/src/main/kotlin/momosetkn/liquibase/command/client/LiquibaseCommandExecutor.kt
@@ -1,16 +1,27 @@
 package momosetkn.liquibase.command.client
 
 import liquibase.command.CommandScope
+import momosetkn.liquibase.scope.CustomScope
 
 object LiquibaseCommandExecutor {
     private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
+
+    // TODO: mopve ConfigureLiquibase
+    var everyUseNewClassloader = false
 
     fun executeCommand(
         command: List<String>,
         args: List<Pair<String, String>>,
     ) {
         @Suppress("SpreadOperator")
-        val commandScope = CommandScope(*command.toTypedArray())
+        val commandScope = if (everyUseNewClassloader) {
+            CustomScope.createWithNewClassloader(
+                CommandScope::class,
+                *command.toTypedArray()
+            )
+        } else {
+            CommandScope(*command.toTypedArray())
+        }
         args.forEach { arg ->
             val (key, value) = arg
             commandScope.addArgumentValue(key, value)

--- a/command-client/src/main/kotlin/momosetkn/liquibase/command/client/LiquibaseCommandExecutor.kt
+++ b/command-client/src/main/kotlin/momosetkn/liquibase/command/client/LiquibaseCommandExecutor.kt
@@ -6,15 +6,12 @@ import momosetkn.liquibase.scope.CustomScope
 object LiquibaseCommandExecutor {
     private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
 
-    // TODO: mopve ConfigureLiquibase
-    var everyUseNewClassloader = false
-
     fun executeCommand(
         command: List<String>,
         args: List<Pair<String, String>>,
     ) {
         @Suppress("SpreadOperator")
-        val commandScope = if (everyUseNewClassloader) {
+        val commandScope = if (LiquibaseCommandClient.everyUseNewClassloader) {
             CustomScope.createWithNewClassloader(
                 CommandScope::class,
                 *command.toTypedArray()

--- a/compiled-parser/detekt-baseline.xml
+++ b/compiled-parser/detekt-baseline.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
-  <CurrentIssues>
-    <ID>ForbiddenComment:KotlinCompiledChangeLogDslOverride.kt$KotlinCompiledChangeLogDslOverride$// TODO: require sort by this method?</ID>
-  </CurrentIssues>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/custom-exposed-migration-change/detekt-baseline.xml
+++ b/custom-exposed-migration-change/detekt-baseline.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
-  <CurrentIssues>
-    <ID>ForbiddenComment:RollbackTaskCustomExposedMigrationChange.kt$RollbackTaskCustomExposedMigrationChange$// FIXME: CustomTaskRollback has a bug that causes it to be rolled back twice, but there is a workaround.</ID>
-  </CurrentIssues>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/custom-jooq-change/detekt-baseline.xml
+++ b/custom-jooq-change/detekt-baseline.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
-  <CurrentIssues>
-    <ID>ForbiddenComment:RollbackTaskCustomJooqChange.kt$RollbackTaskCustomJooqChange$// FIXME: CustomTaskRollback has a bug that causes it to be rolled back twice, but there is a workaround.</ID>
-  </CurrentIssues>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/custom-komapper-jdbc-change/detekt-baseline.xml
+++ b/custom-komapper-jdbc-change/detekt-baseline.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
-  <CurrentIssues>
-    <ID>ForbiddenComment:RollbackTaskCustomKomapperJdbcChange.kt$RollbackTaskCustomKomapperJdbcChange$// FIXME: CustomTaskRollback has a bug that causes it to be rolled back twice, but there is a workaround.</ID>
-  </CurrentIssues>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/custom-ktorm-change/detekt-baseline.xml
+++ b/custom-ktorm-change/detekt-baseline.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
-  <CurrentIssues>
-    <ID>ForbiddenComment:RollbackTaskCustomExposedMigrationChange.kt$RollbackTaskCustomExposedMigrationChange$// FIXME: CustomTaskRollback has a bug that causes it to be rolled back twice, but there is a workaround.</ID>
-  </CurrentIssues>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/dsl/detekt-baseline.xml
+++ b/dsl/detekt-baseline.xml
@@ -1,8 +1,5 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
-  <CurrentIssues>
-    <ID>ForbiddenComment:ChangeLogDsl.kt$ChangeLogDsl$// TODO: confirm</ID>
-    <ID>ForbiddenComment:ChangeLogDsl.kt$ChangeLogDsl$// TODO: set by user</ID>
-  </CurrentIssues>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/integration-test/src/test/kotlin/momosetkn/KotestProjectConfig.kt
+++ b/integration-test/src/test/kotlin/momosetkn/KotestProjectConfig.kt
@@ -1,7 +1,9 @@
 package momosetkn
 
 import io.kotest.core.config.AbstractProjectConfig
+import momosetkn.liquibase.client.LiquibaseClient
 import momosetkn.liquibase.client.configureLiquibase
+import momosetkn.liquibase.command.client.LiquibaseCommandExecutor
 
 class KotestProjectConfig : AbstractProjectConfig() {
     init {
@@ -12,8 +14,9 @@ class KotestProjectConfig : AbstractProjectConfig() {
                 }
             }
         }
+        LiquibaseCommandExecutor.everyUseNewClassloader = true
+        LiquibaseClient.everyUseNewClassloader = true
     }
 
-    // TODO: off parallelism. because liquibase generateChangeLog is not threadSafe.
-//    override val parallelism = 4
+    override val parallelism = 4
 }

--- a/integration-test/src/test/kotlin/momosetkn/KotestProjectConfig.kt
+++ b/integration-test/src/test/kotlin/momosetkn/KotestProjectConfig.kt
@@ -3,7 +3,7 @@ package momosetkn
 import io.kotest.core.config.AbstractProjectConfig
 import momosetkn.liquibase.client.LiquibaseClient
 import momosetkn.liquibase.client.configureLiquibase
-import momosetkn.liquibase.command.client.LiquibaseCommandExecutor
+import momosetkn.liquibase.command.client.LiquibaseCommandClient
 
 class KotestProjectConfig : AbstractProjectConfig() {
     init {
@@ -14,7 +14,7 @@ class KotestProjectConfig : AbstractProjectConfig() {
                 }
             }
         }
-        LiquibaseCommandExecutor.everyUseNewClassloader = true
+        LiquibaseCommandClient.everyUseNewClassloader = true
         LiquibaseClient.everyUseNewClassloader = true
     }
 

--- a/liquibase-internal/build.gradle.kts
+++ b/liquibase-internal/build.gradle.kts
@@ -1,13 +1,15 @@
 val liquibaseVersion = rootProject.properties["liquibaseVersion"] as String
 val kotestVersion = rootProject.properties["kotestVersion"] as String
 val slf4jVersion = rootProject.properties["slf4jVersion"] as String
+val kotlinVersion = rootProject.properties["kotlinVersion"] as String
 
 dependencies {
     // liquibase
     implementation("org.liquibase:liquibase-core:$liquibaseVersion")
-    api(project(":liquibase-internal"))
     // log
     api("org.slf4j:slf4j-api:$slf4jVersion")
+    // reflection
+    api("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
 
     // test
     testImplementation("io.kotest:kotest-framework-engine-jvm:$kotestVersion")

--- a/liquibase-internal/src/main/java/momosetkn/liquibase/scope/ScopeUtils.java
+++ b/liquibase-internal/src/main/java/momosetkn/liquibase/scope/ScopeUtils.java
@@ -1,0 +1,104 @@
+package momosetkn.liquibase.scope;
+
+import liquibase.ChecksumVersion;
+import liquibase.Scope;
+import liquibase.SingletonScopeManager;
+import liquibase.configuration.LiquibaseConfiguration;
+import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.logging.LogService;
+import liquibase.logging.core.JavaLogService;
+import liquibase.logging.core.LogServiceFactory;
+import liquibase.osgi.ContainerChecker;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.servicelocator.ServiceLocator;
+import liquibase.ui.ConsoleUIService;
+import liquibase.util.SmartMap;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+
+public class ScopeUtils {
+    private static final Field valuesField;
+    private static final Constructor<Scope> scopeConstructor;
+
+    static {
+        try {
+            valuesField = Scope.class.getDeclaredField("values");
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+        valuesField.setAccessible(true);
+
+        try {
+            scopeConstructor = Scope.class.getDeclaredConstructor();
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+        scopeConstructor.setAccessible(true);
+    }
+
+    /**
+     * Set scope by specify customServiceLocator
+     * <p>
+     * alternative {@link liquibase.Scope#getCurrentScope}
+     * for inject {@link CustomServiceLocator}
+     *
+     * @param customServiceLocator specify customServiceLocator
+     */
+    public static Scope createCustomRootScope(
+            ServiceLocator customServiceLocator
+    ) throws InvocationTargetException, InstantiationException, IllegalAccessException {
+        var scopeManager = new NonProtectedSingletonScopeManager();
+        Scope.setScopeManager(scopeManager);
+        if (scopeManager.getCurrentScope() == null) {
+            Scope rootScope = createScope();
+            scopeManager.setCurrentScopeNonProtected(rootScope);
+
+            SmartMap values = getSmartMap(rootScope);
+
+            values.put(Scope.Attr.logService.name(), new JavaLogService());
+            values.put(Scope.Attr.serviceLocator.name(), customServiceLocator);
+            values.put(Scope.Attr.resourceAccessor.name(), new ClassLoaderResourceAccessor());
+            values.put(Scope.Attr.latestChecksumVersion.name(), ChecksumVersion.V9);
+            values.put(Scope.Attr.checksumVersion.name(), ChecksumVersion.latest());
+
+            values.put(Scope.Attr.ui.name(), new ConsoleUIService());
+            rootScope.getSingleton(LiquibaseConfiguration.class).init(rootScope);
+
+            LogService overrideLogService = rootScope.getSingleton(LogServiceFactory.class).getDefaultLogService();
+            if (overrideLogService == null) {
+                throw new UnexpectedLiquibaseException("Cannot find default log service");
+            }
+            values.put(Scope.Attr.logService.name(), overrideLogService);
+
+            //check for higher-priority serviceLocator
+            ServiceLocator serviceLocator = rootScope.getServiceLocator();
+            for (ServiceLocator possibleLocator : serviceLocator.findInstances(ServiceLocator.class)) {
+                if (possibleLocator.getPriority() > serviceLocator.getPriority()) {
+                    serviceLocator = possibleLocator;
+                }
+            }
+
+            values.put(Scope.Attr.serviceLocator.name(), serviceLocator);
+            values.put(Scope.Attr.osgiPlatform.name(), ContainerChecker.isOsgiPlatform());
+        }
+        return scopeManager.getCurrentScope();
+    }
+
+    private static SmartMap getSmartMap(Scope rootScope) throws IllegalAccessException {
+        var values = (SmartMap) valuesField.get(rootScope);
+        return values;
+    }
+
+    private static Scope createScope() throws InstantiationException, IllegalAccessException, InvocationTargetException {
+        var rootScope = scopeConstructor.newInstance();
+        return rootScope;
+    }
+
+    private static class NonProtectedSingletonScopeManager extends SingletonScopeManager {
+        protected synchronized void setCurrentScopeNonProtected(Scope scope) {
+            this.setCurrentScope(scope);
+        }
+    }
+}

--- a/liquibase-internal/src/main/java/momosetkn/liquibase/scope/ScopeUtils.java
+++ b/liquibase-internal/src/main/java/momosetkn/liquibase/scope/ScopeUtils.java
@@ -46,7 +46,7 @@ public class ScopeUtils {
      *
      * @param customServiceLocator specify customServiceLocator
      */
-    public static Scope createCustomRootScope(
+    public Scope createCustomRootScope(
             ServiceLocator customServiceLocator
     ) throws InvocationTargetException, InstantiationException, IllegalAccessException {
         var scopeManager = new NonProtectedSingletonScopeManager();

--- a/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/CustomScope.kt
+++ b/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/CustomScope.kt
@@ -1,19 +1,53 @@
 package momosetkn.liquibase.scope
 
+import liquibase.Scope
+import liquibase.listener.LiquibaseListener
 import kotlin.reflect.KClass
 
 object CustomScope {
-    fun <T : Any> createWithNewClassloader(
+    fun <T : Any, R> executeWithNewClassloader(
         clazz: KClass<T>,
         vararg args: Any,
-    ): T {
+        block: (T) -> R,
+    ): R {
         val classloader = ReflectionUtils::getURLClassloaderByClass
         val customServiceLocator = CustomServiceLocator(classloader)
-        ScopeUtils.createCustomRootScope(customServiceLocator)
-        return ReflectionUtils.getInstanceWithClassLoader(
+
+        val map = mapOf(
+            Scope.Attr.serviceLocator.name to customServiceLocator,
+        )
+        val instance = ReflectionUtils.getInstanceWithClassLoader(
             clazz.java,
             classloader,
             *args,
         )
+        val scopeId = Scope.enter(null, map)
+
+        try {
+            return block(instance)
+        } finally {
+            Scope.exit(scopeId)
+        }
+    }
+
+    @Throws(Exception::class)
+    fun enter(listener: LiquibaseListener?, scopeValues: Map<String, Any?>): String {
+        val scopeUtils = ReflectionUtils.getInstanceWithClassLoader(
+            clazz = ScopeUtils::class.java,
+            getClassloaderByClass = ReflectionUtils::getURLClassloaderByClass,
+        )
+        val classloader = ReflectionUtils::getURLClassloaderByClass
+        val customServiceLocator = CustomServiceLocator(classloader)
+        val scope = scopeUtils.createCustomRootScope(customServiceLocator)
+        val child = ExScope(scope, scopeValues)
+        child.listener = listener
+        Scope.scopeManager.get().setCurrentScope(child)
+
+        return child.scopeId
     }
 }
+
+class ExScope(
+    parent: Scope,
+    scopeValues: Map<String, Any?>
+) : Scope(parent, scopeValues)

--- a/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/CustomScope.kt
+++ b/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/CustomScope.kt
@@ -1,0 +1,19 @@
+package momosetkn.liquibase.scope
+
+import kotlin.reflect.KClass
+
+object CustomScope {
+    fun <T : Any> createWithNewClassloader(
+        clazz: KClass<T>,
+        vararg args: Any,
+    ): T {
+        val classloader = ReflectionUtils::getURLClassloaderByClass
+        val customServiceLocator = CustomServiceLocator(classloader)
+        ScopeUtils.createCustomRootScope(customServiceLocator)
+        return ReflectionUtils.getInstanceWithClassLoader(
+            clazz,
+            classloader,
+            *args,
+        )
+    }
+}

--- a/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/CustomScope.kt
+++ b/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/CustomScope.kt
@@ -11,7 +11,7 @@ object CustomScope {
         val customServiceLocator = CustomServiceLocator(classloader)
         ScopeUtils.createCustomRootScope(customServiceLocator)
         return ReflectionUtils.getInstanceWithClassLoader(
-            clazz,
+            clazz.java,
             classloader,
             *args,
         )

--- a/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/CustomServiceLocator.kt
+++ b/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/CustomServiceLocator.kt
@@ -1,0 +1,42 @@
+package momosetkn.liquibase.scope
+
+import liquibase.exception.ServiceNotFoundException
+import liquibase.plugin.Plugin
+import liquibase.servicelocator.ServiceLocator
+import momosetkn.liquibase.scope.ReflectionUtils.getURLClassloaderByClass
+import java.util.Collections
+import java.util.ServiceLoader
+
+/**
+ * ServiceLoad with customClassloader[getURLClassloaderByClass]
+ * alternative [liquibase.servicelocator.StandardServiceLocator]
+ */
+class CustomServiceLocator(
+    private val getClassloaderByClass: (Class<*>) -> ClassLoader
+) : ServiceLocator {
+    private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
+
+    override fun getPriority(): Int {
+        return Plugin.PRIORITY_DEFAULT
+    }
+
+    @Throws(ServiceNotFoundException::class)
+    override fun <T : Any> findInstances(interfaceType: Class<T>): List<T> {
+        val allInstances: MutableList<T> = ArrayList()
+
+        val services: Iterator<T> =
+            ServiceLoader.load(interfaceType, getClassloaderByClass(interfaceType)).iterator()
+        @Suppress("TooGenericExceptionCaught")
+        while (services.hasNext()) {
+            try {
+                val service = services.next()
+                log.debug("Loaded " + interfaceType.name + " instance " + service::class.qualifiedName)
+                allInstances.add(service)
+            } catch (e: Throwable) {
+                log.warn(e.message, e)
+            }
+        }
+
+        return Collections.unmodifiableList(allInstances)
+    }
+}

--- a/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/ReflectionUtils.kt
+++ b/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/ReflectionUtils.kt
@@ -3,11 +3,10 @@ package momosetkn.liquibase.scope
 import java.lang.reflect.Constructor
 import java.net.URL
 import java.net.URLClassLoader
-import kotlin.reflect.KClass
 
 object ReflectionUtils {
     fun <T : Any> getInstanceWithClassLoader(
-        clazz: KClass<T>,
+        clazz: Class<T>,
         getClassloaderByClass: (Class<*>) -> ClassLoader,
         vararg args: Any,
     ): T {
@@ -28,18 +27,18 @@ object ReflectionUtils {
         return classLoader
     }
 
-    private fun <T : Any> isKotlinClazz(clazz: KClass<T>): Boolean {
-        val metadataAnnotation = clazz.java.getAnnotation(Metadata::class.java)
+    private fun <T : Any> isKotlinClazz(clazz: Class<T>): Boolean {
+        val metadataAnnotation = clazz.getAnnotation(Metadata::class.java)
         return metadataAnnotation != null
     }
 
     private fun getConstructor(
-        clazz: KClass<*>,
+        clazz: Class<*>,
         getClassloaderByClass: (Class<*>) -> ClassLoader,
         argsSize: Int,
     ): Constructor<*> {
-        val customClassLoader = getClassloaderByClass(clazz.java)
-        val constructors = customClassLoader.loadClass(clazz.qualifiedName).constructors
+        val customClassLoader = getClassloaderByClass(clazz)
+        val constructors = customClassLoader.loadClass(clazz.canonicalName).constructors
         val constructor = constructors.find {
             it.parameters.size == argsSize
         } ?: error("not found constructor. clazz: $clazz")

--- a/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/ReflectionUtils.kt
+++ b/liquibase-internal/src/main/kotlin/momosetkn/liquibase/scope/ReflectionUtils.kt
@@ -1,0 +1,48 @@
+package momosetkn.liquibase.scope
+
+import java.lang.reflect.Constructor
+import java.net.URL
+import java.net.URLClassLoader
+import kotlin.reflect.KClass
+
+object ReflectionUtils {
+    fun <T : Any> getInstanceWithClassLoader(
+        clazz: KClass<T>,
+        getClassloaderByClass: (Class<*>) -> ClassLoader,
+        vararg args: Any,
+    ): T {
+        val constructor = getConstructor(clazz, getClassloaderByClass, args.size)
+
+        val isKotlin = isKotlinClazz(clazz)
+        @Suppress("UNCHECKED_CAST")
+        return if (isKotlin) {
+            constructor.newInstance(*args)
+        } else {
+            constructor.newInstance(args)
+        } as T
+    }
+
+    fun getURLClassloaderByClass(interfaceType: Class<*>): URLClassLoader {
+        val location = interfaceType.getProtectionDomain().codeSource.location
+        val classLoader = URLClassLoader(arrayOf<URL>(location))
+        return classLoader
+    }
+
+    private fun <T : Any> isKotlinClazz(clazz: KClass<T>): Boolean {
+        val metadataAnnotation = clazz.java.getAnnotation(Metadata::class.java)
+        return metadataAnnotation != null
+    }
+
+    private fun getConstructor(
+        clazz: KClass<*>,
+        getClassloaderByClass: (Class<*>) -> ClassLoader,
+        argsSize: Int,
+    ): Constructor<*> {
+        val customClassLoader = getClassloaderByClass(clazz.java)
+        val constructors = customClassLoader.loadClass(clazz.qualifiedName).constructors
+        val constructor = constructors.find {
+            it.parameters.size == argsSize
+        } ?: error("not found constructor. clazz: $clazz")
+        return constructor
+    }
+}

--- a/liquibase-internal/src/test/kotlin/momosetkn/liquibase/scope/ReflectionUtilsSpec.kt
+++ b/liquibase-internal/src/test/kotlin/momosetkn/liquibase/scope/ReflectionUtilsSpec.kt
@@ -1,0 +1,29 @@
+package momosetkn.liquibase.scope
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.types.shouldBeInstanceOf
+import liquibase.command.CommandScope
+
+class ReflectionUtilsSpec : FunSpec({
+    val classloader = ReflectionUtils::getURLClassloaderByClass
+    context("getInstanceByAntherLoader") {
+        context("java class") {
+            val command = arrayOf("update")
+            test("can create instance") {
+                val actual = ReflectionUtils.getInstanceWithClassLoader(CommandScope::class, classloader, *command)
+                actual.shouldBeInstanceOf<CommandScope>()
+            }
+        }
+        context("kotlin class") {
+            val command = arrayOf("update")
+            test("can create instance") {
+                val actual = ReflectionUtils.getInstanceWithClassLoader(KotlinClass::class, classloader, *command)
+                actual.shouldBeInstanceOf<KotlinClass>()
+            }
+        }
+    }
+})
+
+data class KotlinClass(
+    val data: String,
+)

--- a/liquibase-internal/src/test/kotlin/momosetkn/liquibase/scope/ReflectionUtilsSpec.kt
+++ b/liquibase-internal/src/test/kotlin/momosetkn/liquibase/scope/ReflectionUtilsSpec.kt
@@ -10,14 +10,14 @@ class ReflectionUtilsSpec : FunSpec({
         context("java class") {
             val command = arrayOf("update")
             test("can create instance") {
-                val actual = ReflectionUtils.getInstanceWithClassLoader(CommandScope::class, classloader, *command)
+                val actual = ReflectionUtils.getInstanceWithClassLoader(CommandScope::class.java, classloader, *command)
                 actual.shouldBeInstanceOf<CommandScope>()
             }
         }
         context("kotlin class") {
             val command = arrayOf("update")
             test("can create instance") {
-                val actual = ReflectionUtils.getInstanceWithClassLoader(KotlinClass::class, classloader, *command)
+                val actual = ReflectionUtils.getInstanceWithClassLoader(KotlinClass::class.java, classloader, *command)
                 actual.shouldBeInstanceOf<KotlinClass>()
             }
         }

--- a/liquibase-kotlin.custom-komapper-jdbc-change-unit-test/build.gradle.kts
+++ b/liquibase-kotlin.custom-komapper-jdbc-change-unit-test/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 
     // test
     testImplementation(kotlin("test"))
+    testImplementation(kotlin("reflect"))
     testImplementation("io.kotest:kotest-framework-engine-jvm:$kotestVersion")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,3 +39,5 @@ include("custom-ktorm-change")
 // starter
 include("starter-compiled")
 include("starter-script")
+// internal
+include("liquibase-internal")

--- a/test-utils/src/main/kotlin/momosetkn/utils/MutableChangeLog.kt
+++ b/test-utils/src/main/kotlin/momosetkn/utils/MutableChangeLog.kt
@@ -2,11 +2,16 @@ package momosetkn.utils
 
 import momosetkn.liquibase.kotlin.dsl.ChangeLogDsl
 import momosetkn.liquibase.kotlin.parser.KotlinCompiledDatabaseChangeLog
+import momosetkn.utils.children.MutableChangeLog1
+import momosetkn.utils.children.MutableChangeLog2
+import momosetkn.utils.children.MutableChangeLog3
+import momosetkn.utils.children.MutableChangeLog4
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
 private typealias Key = Pair<Long, KClass<out MutableDsl>>
-private typealias DslBlock = ChangeLogDsl.() -> Unit
+typealias ChangeLogDslBlock = ChangeLogDsl.() -> Unit
+typealias ChangeLogBuilderDslBlock = MutableChangeLogBuilderDsl.() -> Unit
 
 class MutableChangeLog : KotlinCompiledDatabaseChangeLog({
     evalDsl()
@@ -15,8 +20,12 @@ class MutableChangeLog : KotlinCompiledDatabaseChangeLog({
 }
 
 interface MutableDsl {
-    fun set(block: DslBlock) {
+    fun set(block: ChangeLogDslBlock) {
         mutableThreadLocalDsls[key()] = block
+    }
+
+    fun get(): ChangeLogDslBlock? {
+        return mutableThreadLocalDsls[key()]
     }
 
     fun clear() {
@@ -32,11 +41,76 @@ interface MutableDsl {
         Pair(Thread.currentThread().id, this::class)
 
     companion object {
-        private val mutableThreadLocalDsls = ConcurrentHashMap<Key, DslBlock>()
+        private val mutableThreadLocalDsls = ConcurrentHashMap<Key, ChangeLogDslBlock>()
+    }
+}
 
-        @Synchronized
-        fun clear() {
-            mutableThreadLocalDsls.clear()
+class MutableChangeLogBuilderDsl {
+    internal var changeLogDslBlock: ChangeLogDslBlock? = null
+    fun changeLog(block: ChangeLogDslBlock): ChangeLogDslBlock {
+        this.changeLogDslBlock = block
+        return block
+    }
+
+    internal var changeLog1DslBlock: ChangeLogDslBlock? = null
+    fun changeLog1(block: ChangeLogDslBlock) {
+        this.changeLog1DslBlock = block
+    }
+
+    internal var changeLog2DslBlock: ChangeLogDslBlock? = null
+    fun changeLog2(block: ChangeLogDslBlock) {
+        this.changeLog1DslBlock = block
+    }
+
+    internal var changeLog3DslBlock: ChangeLogDslBlock? = null
+    fun changeLog3(block: ChangeLogDslBlock) {
+        this.changeLog3DslBlock = block
+    }
+
+    internal var changeLog4DslBlock: ChangeLogDslBlock? = null
+    fun changeLog4(block: ChangeLogDslBlock) {
+        this.changeLog4DslBlock = block
+    }
+
+    fun set() {
+        val immutableChangeLogDslBlock = changeLogDslBlock
+        val immutableChangeLog1dslBlock = changeLog1DslBlock
+        val immutableChangeLog2dslBlock = changeLog2DslBlock
+        val immutableChangeLog3dslBlock = changeLog3DslBlock
+        val immutableChangeLog4dslBlock = changeLog4DslBlock
+
+        if (immutableChangeLogDslBlock != null) {
+            MutableChangeLog.set(immutableChangeLogDslBlock)
+        } else {
+            MutableChangeLog.clear()
+        }
+        if (immutableChangeLog1dslBlock != null) {
+            MutableChangeLog1.set(immutableChangeLog1dslBlock)
+        } else {
+            MutableChangeLog1.clear()
+        }
+        if (immutableChangeLog2dslBlock != null) {
+            MutableChangeLog2.set(immutableChangeLog2dslBlock)
+        } else {
+            MutableChangeLog2.clear()
+        }
+        if (immutableChangeLog3dslBlock != null) {
+            MutableChangeLog3.set(immutableChangeLog3dslBlock)
+        } else {
+            MutableChangeLog3.clear()
+        }
+        if (immutableChangeLog4dslBlock != null) {
+            MutableChangeLog4.set(immutableChangeLog4dslBlock)
+        } else {
+            MutableChangeLog4.clear()
         }
     }
 }
+
+fun changeLogsDsl(block: ChangeLogBuilderDslBlock): MutableChangeLogBuilderDsl {
+    val dslDsl = MutableChangeLogBuilderDsl()
+    block(dslDsl)
+    return dslDsl
+}
+
+fun changeLogDsl(block: ChangeLogDslBlock) = block


### PR DESCRIPTION
Liquibase was not thread-safe. I chose not to fix the liquibase issue due to the liquibase complexity involved.
Instead, I resolved the thread-safety issue by using a new class loader

and refactoring MutableChangeLog