### PR TITLE
Update the JDK while maintaining the target version.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Setup gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/deploy-central-portal.yml
+++ b/.github/workflows/deploy-central-portal.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: Setup gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.github/workflows/test-master-version-liquibase.yml
+++ b/.github/workflows/test-master-version-liquibase.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
 
       - name: setup gradle
         uses: gradle/actions/setup-gradle@v4

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=17.0.12-tem
+java=21.0.6-tem

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,9 @@ val artifactIdPrefix: String by project
 val artifactVersion: String by project
 val artifactGroup: String by project
 
+val jvmTargetVersion = 17
+val javaLanguageVersion = 21
+
 plugins {
     kotlin("jvm")
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
@@ -33,15 +36,10 @@ if (artifactVersion.isNotEmpty()) {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(javaLanguageVersion))
     }
     withSourcesJar()
     withJavadocJar()
-}
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-    }
 }
 
 allprojects {
@@ -61,10 +59,21 @@ allprojects {
         }
     }
 
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-            freeCompilerArgs.addAll(listOf("-Xjvm-default=all"))
+    tasks {
+        withType<JavaCompile>().configureEach {
+            options.release.set(jvmTargetVersion)
+        }
+
+        withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+            compilerOptions {
+                freeCompilerArgs.addAll(
+                    listOf(
+                        "-Xjvm-default=all",
+                        "-Xjdk-release=$jvmTargetVersion"
+                    )
+                )
+                jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(jvmTargetVersion.toString()))
+            }
         }
     }
 


### PR DESCRIPTION
Because it cannot accommodate libraries like jOOQ that use Java 21.

see: https://github.com/momosetkn/liquibase-kotlin/pull/141