### PR TITLE
Fix typo in DynamoDB and MongoDB args

### DIFF
--- a/client/src/main/kotlin/momosetkn/liquibase/client/LiquibaseArgs.kt
+++ b/client/src/main/kotlin/momosetkn/liquibase/client/LiquibaseArgs.kt
@@ -235,7 +235,7 @@ data class LiquibaseExtensionsArgs(
     var dynamodbWaitersEnabled: Boolean? = null,
     var dynamodbWaitersFailOnTimeout: Boolean? = null,
     var dynamodbWaitersLogNotificationEnabled: Boolean? = null,
-    var dynamodbWaitersLogNotificationIntervar: Int? = null,
+    var dynamodbWaitersLogNotificationInterval: Int? = null,
     var dynamodbWaiterCreateFixedDelayBackoffStrategyDuration: Int? = null,
     var dynamodbWaiterCreateMaxAttempts: Int? = null,
     var dynamodbWaiterCreateTotalTimeout: Int? = null,
@@ -257,7 +257,7 @@ data class LiquibaseExtensionsArgs(
             "dynamodb-waiters-enabled" to dynamodbWaitersEnabled,
             "dynamodb-waiters-fail-on-timeout" to dynamodbWaitersFailOnTimeout,
             "dynamodb-waiters-log-notification-enabled" to dynamodbWaitersLogNotificationEnabled,
-            "dynamodb-waiters-log-notification-intervar" to dynamodbWaitersLogNotificationIntervar,
+            "dynamodb-waiters-log-notification-interval" to dynamodbWaitersLogNotificationInterval,
             "dynamodb-waiter-create-fixed-delay-backoff-strategy-duration" to dynamodbWaiterCreateFixedDelayBackoffStrategyDuration,
             "dynamodb-waiter-create-max-attempts" to dynamodbWaiterCreateMaxAttempts,
             "dynamodb-waiter-create-total-timeout" to dynamodbWaiterCreateTotalTimeout,
@@ -275,13 +275,13 @@ data class LiquibaseExtensionsArgs(
 data class LiquibaseMongoDBArgs(
     var adjustTrackingTablesOnStartup: Boolean? = null,
     var retryWrites: Boolean? = null,
-    var supportsvaridator: Boolean? = null,
+    var supportsValidator: Boolean? = null,
 ) : LiquibaseGlobalArgs {
     override fun serialize(): List<Pair<String, String?>> {
         return listOf(
             "adjust-tracking-tables-on-startup" to adjustTrackingTablesOnStartup,
             "retry-writes" to retryWrites,
-            "supports-varidator" to supportsvaridator,
+            "supports-validator" to supportsValidator,
         ).map { (k, v) -> k to v?.toString() }
     }
 }

--- a/command-client/src/main/kotlin/momosetkn/liquibase/command/client/LiquibaseArgs.kt
+++ b/command-client/src/main/kotlin/momosetkn/liquibase/command/client/LiquibaseArgs.kt
@@ -265,7 +265,7 @@ data class LiquibaseExtensionsArgs(
     var dynamodbWaitersEnabled: Boolean? = null,
     var dynamodbWaitersFailOnTimeout: Boolean? = null,
     var dynamodbWaitersLogNotificationEnabled: Boolean? = null,
-    var dynamodbWaitersLogNotificationIntervar: Int? = null,
+    var dynamodbWaitersLogNotificationInterval: Int? = null,
     var dynamodbWaiterCreateFixedDelayBackoffStrategyDuration: Int? = null,
     var dynamodbWaiterCreateMaxAttempts: Int? = null,
     var dynamodbWaiterCreateTotalTimeout: Int? = null,
@@ -288,7 +288,7 @@ data class LiquibaseExtensionsArgs(
             dynamodbWaitersEnabled?.let { "dynamodb-waiters-enabled" to it },
             dynamodbWaitersFailOnTimeout?.let { "dynamodb-waiters-fail-on-timeout" to it },
             dynamodbWaitersLogNotificationEnabled?.let { "dynamodb-waiters-log-notification-enabled" to it },
-            dynamodbWaitersLogNotificationIntervar?.let { "dynamodb-waiters-log-notification-intervar" to it },
+            dynamodbWaitersLogNotificationInterval?.let { "dynamodb-waiters-log-notification-interval" to it },
             dynamodbWaiterCreateFixedDelayBackoffStrategyDuration?.let {
                 "dynamodb-waiter-create-fixed-delay-backoff-strategy-duration" to it
             },
@@ -312,13 +312,13 @@ data class LiquibaseExtensionsArgs(
 data class LiquibaseMongoDBArgs(
     var adjustTrackingTablesOnStartup: Boolean? = null,
     var retryWrites: Boolean? = null,
-    var supportsvaridator: Boolean? = null,
+    var supportsValidator: Boolean? = null,
 ) : LiquibaseGlobalArgs {
     override fun serialize(): List<Pair<String, String>> {
         return listOfNotNull(
             adjustTrackingTablesOnStartup?.let { "adjust-tracking-tables-on-startup" to it },
             retryWrites?.let { "retry-writes" to it },
-            supportsvaridator?.let { "supports-varidator" to it },
+            supportsValidator?.let { "supports-validator" to it },
         ).map { (k, v) -> k to v.toString() }
     }
 }


### PR DESCRIPTION
## Summary
- correct typo `intervar` -> `interval`
- fix `supportsvaridator` -> `supportsValidator`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f828ff6648323b05d30361ca9b5e4