### PR TITLE
Remove kotlin ksp rules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,4 @@
 val kotestVersion: String by project
-val kotlinVersion: String by project
-val kspVersion: String by project
 val liquibaseVersion: String by project
 val artifactIdPrefix: String by project
 val artifactVersion: String by project
@@ -21,14 +19,6 @@ plugins {
 group = artifactGroup
 version = artifactVersion
 description = "Liquibase kotlin(DSL, Wrapper client, ORM integration)"
-
-// check ksp version
-run {
-    val kotlinPartInKsp = kspVersion.split("-")[0]
-    check(kotlinPartInKsp == kotlinVersion) {
-        "KSP version mismatch: expected $kotlinVersion-<suffix>, but was $kspVersion"
-    }
-}
 
 fun validateArtifactVersion(artifactVersion: String) {
     val (artifactVersionLiquibase, artifactVersionLiquibaseKotlin) = artifactVersion.split("-")

--- a/renovate.json
+++ b/renovate.json
@@ -7,16 +7,5 @@
   "labels": [
     "dependencies"
   ],
-  "packageRules": [
-    {
-      "groupName": "Kotlin & KSP",
-      "matchManagers": [
-        "gradle"
-      ],
-      "matchPackageNames": [
-        "/org.jetbrains.kotlin/",
-        "/com.google.devtools.ksp/"
-      ]
-    }
-  ]
+  "packageRules": []
 }


### PR DESCRIPTION
[github.com/google/ksp/releases/tag/2.3.0](https://t.co/dVdGFYpNIa)
> KSP version is no longer tied to the Kotlin compiler version

I had added a check to make sure the Kotlin and KSP versions matched, but the version naming changed, so I guess we should remove that check.